### PR TITLE
fix missed code

### DIFF
--- a/backend/bankapi/models.py
+++ b/backend/bankapi/models.py
@@ -35,6 +35,11 @@ class BankTransaction(models.Model):
                                related_name='account_to')
     transfer_amount = models.PositiveIntegerField()
 
+    @classmethod
+    def create(cls, transfer_amount=transfer_amount, acc_from=acc_from, acc_to=acc_to):
+        entity = cls(transfer_amount=transfer_amount, acc_from=acc_from, acc_to=acc_to)
+        entity.save()
+
     def __str__(self):
         return 'Transact {0} roubles from {1} to {2} account'.format(
             self.transfer_amount, self.acc_from, self.acc_to,


### PR DESCRIPTION
but there is still a raise condition vulnerability

described in code
```Python
# if this code executed at exact same time for single acc_from_obj
# two different transactions could be created for same account_balance value
# in sqlite we can see that so some of transactions was created but account_balance has no changes
# simple way to reproduce set breakpoint at next line and make two different requests transferring
# balance from acc1 to acc2 and second one from acc1 to acc3 after both requests hit the breakpoint
# just run both of them
```